### PR TITLE
On supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ These include
  - Selecting several columns at once using `*` globbing and `{A,B}` shell patterns.
  - Flattening source files containing arrays by storing one array element each in the DataFrame, duplicating any scalar variables.
 
+Python versions supported:
+
+[![](https://img.shields.io/badge/python-2.6-blue.svg)](https://badge.fury.io/py/root_pandas)
+[![](https://img.shields.io/badge/python-2.7-blue.svg)](https://badge.fury.io/py/root_pandas)
+[![](https://img.shields.io/badge/python-3.4-blue.svg)](https://badge.fury.io/py/root_pandas)
+
+
 ## Reading ROOT files
 
 This is how you can read the contents of a ROOT file into a DataFrame:


### PR DESCRIPTION
I see from Travis that the supported versions are presently 2.7 and 3.4. Would it be at all possible to add 3.5 and 3.6 as for scikit-hep, for consistency? Or that's too demanding right now because of the ROOT builds?