### PR TITLE
Add tests for Python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,26 @@ matrix:
           env: PYTHON=3.4 ROOT=5.34.32
         - python: 3.4
           env: PYTHON=3.4 ROOT=6.04
-    allow_failures:
-        - python: 3.4
+        - python: 3.5
+          env: PYTHON=3.4 ROOT=5.34.32
+        - python: 3.5
+          env: PYTHON=3.4 ROOT=6.04
+        - python: 3.6
+          env: PYTHON=3.4 ROOT=5.34.32
+        - python: 3.6
+          env: PYTHON=3.4 ROOT=6.04
 #install: source ci/install.sh
 install:
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then curl --silent http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh; fi
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then wget -nv http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
-  
+
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a # Useful for debugging any issues with conda
-  - conda config --add channels http://conda.anaconda.org/NLeSC  
+  - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --set show_channel_urls yes
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} rootpy pandas nose
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ These include
  - Selecting several columns at once using `*` globbing and `{A,B}` shell patterns.
  - Flattening source files containing arrays by storing one array element each in the DataFrame, duplicating any scalar variables.
 
+Python versions supported:
+
+[![](https://img.shields.io/badge/python-2.7-blue.svg)](https://badge.fury.io/py/root_pandas)
+[![](https://img.shields.io/badge/python-3.4-blue.svg)](https://badge.fury.io/py/root_pandas)
+[![](https://img.shields.io/badge/python-3.5-blue.svg)](https://badge.fury.io/py/root_pandas)
+[![](https://img.shields.io/badge/python-3.6-blue.svg)](https://badge.fury.io/py/root_pandas)
+
+
 ## Reading ROOT files
 
 This is how you can read the contents of a ROOT file into a DataFrame:


### PR DESCRIPTION
Adds testing on travis for Python 3.5 and 3.6 and no longer allows Python 3.4 to fail.

Expands upon #47 as suggested by @eduardo-rodrigues (with Python 2.6 excluded).