### PR TITLE
setup.py: update of URL and authors/maintainers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,11 @@ def get_version():
 
 setup(name='root_pandas',
       version=get_version(),
-      description='Read and save DataFrames from and to ROOT files',
-      url='http://github.com/chrisburr/root_pandas',
-      author='Chris Burr',
-      author_email='c.b@cern.ch',
+      description='Read and save pandas DataFrames from and to ROOT files',
+      url='http://github.com/scikit-hep/root_pandas',
+      author='the root_pandas developers',
+      maintainer='Chris Burr',
+      maintainer_email='c.b@cern.ch',
       license='MIT',
       install_requires=[
           'numpy',


### PR DESCRIPTION
@chrisburr, would you consider updating the info in the setup.py file as follows? Seems nicer to me for a community package.
I fixed the URL in any case.
There is also the issue of the license. I would push for a BSD-3 license as we have for all Scikit-HEP projects, where possible. Could you give that a thought? This would require some additions as a 1-line header to the various files, see the other projects ...
Let me know :-). Thanks.