### PR TITLE
Fix recursive brace expansion

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -304,10 +304,10 @@ def test_brace_pattern_in_columns():
     assert_frame_equal(df[['var{03}', 'var2', 'var{04}']],
                        reference_df[['var{03}', 'var2', 'var{04}']])
 
-    # # TODO Recursive expansions
-    # df = read_root('tmp.root', columns=[r'var{0{2,3},1{1,3}}'])
-    # assert set(df.columns) == {'var02', 'var03', 'var11', 'var13'}
-    # assert_frame_equal(df[['var02', 'var03', 'var11', 'var13']],
-    #                    reference_df[['var02', 'var03', 'var11', 'var13']])
+    # Recursive expansions
+    df = read_root('tmp.root', columns=[r'var{0{2,3},1{1,3}}'])
+    assert set(df.columns) == {'var02', 'var03', 'var11', 'var13'}
+    assert_frame_equal(df[['var02', 'var03', 'var11', 'var13']],
+                       reference_df[['var02', 'var03', 'var11', 'var13']])
 
     os.remove('tmp.root')


### PR DESCRIPTION
This addresses and solves #64 and fixes the recursive expansion while keeping branches with braces in their names working as they should.

I have also run some timing tests and it basically doesn't change w.r.t. to the previous solution.

The solution is a copy from
https://rosettacode.org/wiki/Brace_expansion#Python
with some minor adaptions to clearer variable names and at least a sentence describing the functionality. I am not entirely sure about the licensing but as far as I can tell it should be OK.