### PR TITLE
update README to deprecation of do_flatten(flatten=True)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ df = read_root('myfile.root', columns=['noexpand:sqrt(variable1)']
 Working with stored arrays can be a bit inconventient in pandas.
 `root_pandas` makes it easy to flatten your input data, providing you with a DataFrame containing only scalars:
 ```python
-df = read_root('myfile.root', columns=['arrayvariable', 'othervariable'], flatten=True)
+df = read_root('myfile.root', columns=['arrayvariable', 'othervariable'], flatten=['arrayvariable'])
 ```
 
 Assuming the ROOT file contains the array `[1, 2, 3]` in the first `arrayvariable` column, flattening


### PR DESCRIPTION
in root_pandas/readwrite.py the option `flatten=True` is warned as deprecated. This update of the README follows up on the advice given in the warning.