### PR TITLE
Use conda-forge's main channel for ROOT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,10 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda config --add channels conda-forge/label/gcc7
-  - conda config --add channels chrisburr
-  - conda create -q -n testenv python=${PYTHON} nomkl root pandas nose
+  - conda config --add channels conda-forge
+  - conda create -q -n testenv python=${PYTHON} root pandas nose
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
-  - if [ "${PYTHON}" == "3.7" ]; then
-      pip install git+https://github.com/scikit-hep/root_numpy.git;
-    else
-      pip install root_numpy;
-    fi
   - pip install root_numpy rootpy
   - pip install coverage coveralls
 


### PR DESCRIPTION
ROOT is now in the main `conda-forge` channel so that should be used instead of `chrisburr` and `conda-forge/label/gcc7`.